### PR TITLE
Add Datadog Monitoring to CDK TypeScript Lambda Stack

### DIFF
--- a/lib/cdk-ts-lambda-stack.ts
+++ b/lib/cdk-ts-lambda-stack.ts
@@ -20,6 +20,7 @@ import * as cdk from "@aws-cdk/core";
 import { Tags } from "@aws-cdk/core";
 import { Lambda, LambdaProps } from "../constructs/Lambda";
 import { Config } from "./config";
+import { DatadogLambda } from "datadog-cdk-constructs-v2";
 
 export class CdkTsLambdaStack extends cdk.Stack {
   constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
@@ -33,6 +34,21 @@ export class CdkTsLambdaStack extends cdk.Stack {
 
       Tags.of(this).add("APP_NAME", "CDK_SAMPLE");
       Tags.of(this).add("ENVIRONMENT", process.env.ENV_NAME);
+      Tags.of(this).add("team", "serverless");
+
+      const datadogLambda = new DatadogLambda(this, "DatadogLambda", {
+        nodeLayerVersion: 125,
+        extensionLayerVersion: 81,
+        site: "<DATADOG_SITE>",
+        apiKeySecretArn: "<DATADOG_API_KEY_SECRET_ARN>",
+        enableTracing: true,
+        enablePayloads: true
+      });
+
+      datadogLambda.addLambdaFunctions([
+        this.addAdditionFunction(config),
+        this.addMultiplicationFunction(config)
+      ]);
     } else {
       throw new Error("ENV_NAME environment variable is mandatory.");
     }
@@ -47,7 +63,7 @@ export class CdkTsLambdaStack extends cdk.Stack {
       functionRoleName: config.getadditionFuncRoleName(),
     };
 
-    new Lambda(this, config.getadditionFuncName(), lambdaProps);
+    return new Lambda(this, config.getadditionFuncName(), lambdaProps);
   }
 
   private addMultiplicationFunction(config: Config) {
@@ -59,6 +75,6 @@ export class CdkTsLambdaStack extends cdk.Stack {
       functionRoleName: config.getmultiplyFuncRoleName(),
     };
 
-    new Lambda(this, config.getmultiplyFuncName(), lambdaProps);
+    return new Lambda(this, config.getmultiplyFuncName(), lambdaProps);
   }
 }


### PR DESCRIPTION
This pull request introduces Datadog monitoring to the existing AWS CDK TypeScript Lambda stack. By integrating Datadog, we aim to enhance observability and monitoring capabilities for our serverless applications. The changes include importing the Datadog CDK construct, configuring it with necessary parameters, and associating it with existing Lambda functions to enable tracing and payload monitoring.

## Next Steps
- Ensure that the Datadog CDK constructs library is installed by running `npm install datadog-cdk-constructs-v2 --save-dev`.
- Replace `<DATADOG_SITE>` and `<DATADOG_API_KEY_SECRET_ARN>` with your actual Datadog site and API key secret ARN.

## Documentation References
The following Datadog documentation was used to generate this instrumentation. You can refer to these links for additional configuration options or customizations:

- [AWS Lambda Instrumentation for Node.Js](https://docs.datadoghq.com/serverless/aws_lambda/installation/nodejs/?tab=awscdk)


---
*This PR was generated automatically by the DD Instrumenter Agent*